### PR TITLE
Update leaderboard summary stats

### DIFF
--- a/progress-calculator.js
+++ b/progress-calculator.js
@@ -1,22 +1,22 @@
 // Configuration for progress calculations and metrics
 const progressConfig = {
     totalRevenue: {
-        value: 5975700000
+        value: 6209000000
     },
     revenuePerEmployee: {
-        value: 40749368,
+        value: 35265284,
         maxValue: 100000000, // $100MM
         minValue: 0,
         reverseScale: false // Higher is better
     },
     valuationPerEmployee: {
-        value: 111929247,
+        value: 112698115,
         maxValue: 1000000000, // $1B
         minValue: 0,
         reverseScale: false // Higher is better
     },
     teamSize: {
-        value: 29,
+        value: 27,
         maxValue: 100,
         minValue: 1,
         reverseScale: true // Lower is better (closer to 1-person company)


### PR DESCRIPTION
## Summary
- refresh the four homepage summary metrics from the current leaderboard data
- include all 55 ranked rows with numeric annual revenue and employee counts

## Updated values
- Total Revenue: `$6,209,000,000`
- Avg. Revenue/Employee: `$35,265,284`
- Avg. Valuation/Employee: `$112,698,115`
- Avg. Team Size: `27`

## Method
- Total revenue is the sum of Annual Revenue.
- The other three cards preserve the site's existing method: arithmetic averages of each company's Revenue/Employee, Valuation/Employee (for rows with a valuation), and employee count, rounded to whole numbers.